### PR TITLE
Remove Github Packages publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           OSSRH_SIGNING_KEY:  ${{ secrets.OSSRH_SIGNING_KEY }}
           OSSRH_SIGNING_PASSWORD:  ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-          GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           arguments: --no-configuration-cache publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ kotlin {
 val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
 publishOnCentral {
     projectDescription.set("Multiplatform Docker API client")
-    projectLongName.set("yoki")
+    projectLongName.set(project.name)
     licenseName.set("MIT")
     licenseUrl.set("https://github.com/DevNatan/yoki/blob/main/LICENSE")
     projectUrl.set("https://github.com/DevNatan/yoki")
@@ -106,11 +106,6 @@ publishOnCentral {
 
     mavenCentral.user.set(System.getenv("OSSRH_USERNAME"))
     mavenCentral.password.set(provider { System.getenv("OSSRH_PASSWORD") })
-
-    repository("https://maven.pkg.github.com/DevNatan/yoki", "GitHub") {
-        user.set(System.getenv("GITHUB_USERNAME"))
-        password.set(System.getenv("GITHUB_TOKEN"))
-    }
 
     if (!isReleaseVersion)
         mavenCentralSnapshotsRepository()


### PR DESCRIPTION
Yoki is now published on Maven Central so there's no need to publish on GitHub Packages