### PR TITLE
Fix exec creation

### DIFF
--- a/src/commonMain/kotlin/me/devnatan/yoki/models/ProcessConfig.kt
+++ b/src/commonMain/kotlin/me/devnatan/yoki/models/ProcessConfig.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class ProcessConfig internal constructor(
     val privileged: Boolean,
-    val user: String,
+    val user: String? = null,
     val tty: Boolean,
     val entrypoint: String,
     val arguments: List<String>,

--- a/src/commonMain/kotlin/me/devnatan/yoki/resource/container/ContainerResource.kt
+++ b/src/commonMain/kotlin/me/devnatan/yoki/resource/container/ContainerResource.kt
@@ -14,7 +14,6 @@ import me.devnatan.yoki.models.container.ContainerPruneResult
 import me.devnatan.yoki.models.container.ContainerRemoveOptions
 import me.devnatan.yoki.models.container.ContainerSummary
 import me.devnatan.yoki.models.container.ContainerWaitResult
-import me.devnatan.yoki.models.exec.ExecCreateOptions
 import me.devnatan.yoki.resource.image.ImageNotFoundException
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration
@@ -124,14 +123,6 @@ public expect class ContainerResource {
      * @throws YokiResponseException If the container cannot be resized or if an error occurs in the request.
      */
     public suspend fun resizeTTY(container: String, options: ResizeTTYOptions = ResizeTTYOptions())
-
-    /**
-     * Runs a command inside a running container.
-     *
-     * @param container The container id to execute the command.
-     * @param options Exec instance command options.
-     */
-    public suspend fun exec(container: String, options: ExecCreateOptions = ExecCreateOptions()): String
 
     // TODO documentation
     public fun attach(container: String): Flow<Frame>

--- a/src/commonMain/kotlin/me/devnatan/yoki/resource/container/ContainerResourceExt.kt
+++ b/src/commonMain/kotlin/me/devnatan/yoki/resource/container/ContainerResourceExt.kt
@@ -59,16 +59,6 @@ public suspend inline fun ContainerResource.resizeTTY(container: String, options
     resizeTTY(container, ResizeTTYOptions().apply(options))
 }
 
-/**
- * Runs a command inside a running container.
- *
- * @param container The container id to execute the command.
- * @param options Exec instance command options.
- */
-public suspend inline fun ContainerResource.exec(container: String, options: ExecCreateOptions.() -> Unit) {
-    exec(container, ExecCreateOptions().apply(options))
-}
-
 // public inline fun ContainerResource.logs(
 //     id: String,
 //     block: ContainerLogsOptions.() -> Unit,

--- a/src/commonMain/kotlin/me/devnatan/yoki/resource/exec/ExecResourceExt.kt
+++ b/src/commonMain/kotlin/me/devnatan/yoki/resource/exec/ExecResourceExt.kt
@@ -1,0 +1,33 @@
+package me.devnatan.yoki.resource.exec
+
+import me.devnatan.yoki.models.exec.ExecCreateOptions
+import me.devnatan.yoki.models.exec.ExecStartOptions
+import me.devnatan.yoki.resource.container.ContainerNotFoundException
+import me.devnatan.yoki.resource.container.ContainerNotRunningException
+
+/**
+ * Creates a new container.
+ *
+ * @param id The container id to execute the command.
+ * @param options Options to customize the container creation.
+ * @throws ContainerNotFoundException If container instance is not found.
+ * @throws ContainerNotRunningException If the container is not running.
+ */
+public suspend inline fun ExecResource.create(id: String, options: ExecCreateOptions.() -> Unit): String {
+    return create(id, ExecCreateOptions().apply(options))
+}
+
+/**
+ * Starts a previously set up exec instance.
+ *
+ * If detach is true, this endpoint returns immediately after starting the command.
+ * Otherwise, it sets up an interactive session with the command.
+ *
+ * @param id The exec instance id to be started.
+ * @param options Options to customize the exec start.
+ * @throws ExecNotFoundException If exec instance is not found.
+ * @throws ContainerNotRunningException If the container in which the exec instance was created is not running.
+ */
+public suspend inline fun ExecResource.start(id: String, options: ExecStartOptions.() -> Unit = {}) {
+    start(id, ExecStartOptions().apply(options))
+}

--- a/src/commonTest/kotlin/me/devnatan/yoki/resource/exec/ExecContainerIT.kt
+++ b/src/commonTest/kotlin/me/devnatan/yoki/resource/exec/ExecContainerIT.kt
@@ -1,0 +1,56 @@
+package me.devnatan.yoki.resource.exec
+
+import kotlinx.coroutines.test.runTest
+import me.devnatan.yoki.resource.ResourceIT
+import me.devnatan.yoki.withContainer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExecContainerIT : ResourceIT() {
+
+    @Test
+    fun `exec a command in a container`() = runTest {
+        testClient.withContainer(
+            "busybox:latest",
+            {
+                command = listOf("sleep", "infinity")
+            },
+        ) { id ->
+            testClient.containers.start(id)
+
+            val execId = testClient.exec.create(id) {
+                command = listOf("true")
+            }
+
+            testClient.exec.start(execId)
+
+            val exec = testClient.exec.inspect(execId)
+            assertEquals(exec.exitCode, 0)
+
+            testClient.containers.stop(id)
+        }
+    }
+
+    @Test
+    fun `exec a failing command in a container`() = runTest {
+        testClient.withContainer(
+            "busybox:latest",
+            {
+                command = listOf("sleep", "infinity")
+            },
+        ) { id ->
+            testClient.containers.start(id)
+
+            val execId = testClient.exec.create(id) {
+                command = listOf("false")
+            }
+
+            testClient.exec.start(execId)
+
+            val exec = testClient.exec.inspect(execId)
+            assertEquals(exec.exitCode, 1)
+
+            testClient.containers.stop(id)
+        }
+    }
+}

--- a/src/nativeMain/kotlin/me/devnatan/yoki/resource/container/ContainerResource.native.kt
+++ b/src/nativeMain/kotlin/me/devnatan/yoki/resource/container/ContainerResource.native.kt
@@ -13,7 +13,6 @@ import me.devnatan.yoki.models.container.ContainerPruneResult
 import me.devnatan.yoki.models.container.ContainerRemoveOptions
 import me.devnatan.yoki.models.container.ContainerSummary
 import me.devnatan.yoki.models.container.ContainerWaitResult
-import me.devnatan.yoki.models.exec.ExecCreateOptions
 import kotlin.time.Duration
 
 public actual class ContainerResource {
@@ -139,19 +138,6 @@ public actual class ContainerResource {
      * @throws YokiResponseException If the container cannot be resized or if an error occurs in the request.
      */
     public actual suspend fun resizeTTY(container: String, options: ResizeTTYOptions) {
-    }
-
-    /**
-     * Runs a command inside a running container.
-     *
-     * @param container The container id to execute the command.
-     * @param options Exec instance command options.
-     */
-    public actual suspend fun exec(
-        container: String,
-        options: ExecCreateOptions,
-    ): String {
-        TODO("Not yet implemented")
     }
 
     public actual fun attach(container: String): Flow<Frame> {


### PR DESCRIPTION
I moved the exec creation command to ExecResource to mirror the API.
It now correctly returns the exec instance id.